### PR TITLE
fix(cli): resolve bundled config and package.json relative to module

### DIFF
--- a/bin/cli.mjs
+++ b/bin/cli.mjs
@@ -1,7 +1,8 @@
 #!/usr/bin/env node
 
 import { readFileSync, writeFileSync } from 'node:fs';
-import { resolve } from 'node:path';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 import { program } from 'commander';
 import Typograf from 'typograf';
@@ -9,6 +10,7 @@ import Typograf from 'typograf';
 import utils from './utils.mjs';
 import printError from './printError.mjs';
 
+const __dirname = dirname(fileURLToPath(import.meta.url));
 const locales = Typograf.getLocales();
 const types = ['digit', 'name', 'default'];
 
@@ -17,7 +19,7 @@ function splitByCommas(str) {
 }
 
 program
-    .version(JSON.parse(readFileSync('./package.json', 'utf8')).version)
+    .version(JSON.parse(readFileSync(join(__dirname, '../package.json'), 'utf8')).version)
     .usage('[options] <file>')
     .option('-l, --locale <locale>', `set the locale for rules (separated by commas). Available locales: "${locales.join('", "')}". Default: ru`, splitByCommas)
     .option('-d, --disable-rule <rule>', 'disable rules (separated by commas)', splitByCommas)

--- a/bin/utils.mjs
+++ b/bin/utils.mjs
@@ -1,5 +1,6 @@
 import { readFileSync, existsSync, statSync } from 'node:fs';
-import { extname } from 'node:path';
+import { dirname, extname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 import { program } from 'commander';
 
@@ -7,7 +8,8 @@ import lint from './lint.mjs';
 import printError from './printError.mjs';
 import Typograf from 'typograf';
 
-const defaultConfig = JSON.parse(readFileSync('./typograf.json', 'utf8'));
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const defaultConfig = JSON.parse(readFileSync(join(__dirname, '../typograf.json'), 'utf8'));
 
 const DEFAULT_USER_CONFIG = '.typograf.json';
 


### PR DESCRIPTION
The CLI reads `./typograf.json` (bundled default config) and `./package.json` (for `--version`) relative to the **current working directory**. As a result the command crashes with `ENOENT: no such file or directory, open './typograf.json'` when run from any directory other than the package root — which is every real invocation of a globally installed CLI.

```
$ echo "текст" | typograf --stdin
Error: ENOENT: no such file or directory, open './typograf.json'
    at readFileSync (node:fs:440:20)
    at .../bin/utils.mjs:10:34
```

This was introduced when the CLI moved to ESM (6.2.0); the previous CJS version resolved these via `require(.../typograf.json)`, which is module-relative.

Fix: resolve both paths from `import.meta.url` instead of CWD.

- `bin/utils.mjs` — bundled `typograf.json`
- `bin/cli.mjs` — `package.json` for `--version`

Verified the CLI now works from an arbitrary CWD (stdin processing and `--version`); `npm test` (eslint) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)